### PR TITLE
Replace the name of the project lead with Manuel Finelli

### DIFF
--- a/narayana/Team.md
+++ b/narayana/Team.md
@@ -8,7 +8,7 @@ The people listed here currently act in various governance roles with the WildFl
 
 #### Project Lead
 
-Thomas Jenkinson
+Manuel Finelli
 
 #### Maintainers
 


### PR DESCRIPTION
Current policy: https://github.com/wildfly/wildfly-governance/blob/bac6354ada5ee019b8eed6ff391230fb1d172d4b/narayana/GOVERNANCE.md?plain=1#L42
Vote thread: [#announce > Proposing Manuel Finelli as Project Lead for Narayana](https://narayana.zulipchat.com/#narrow/channel/323716-announce/topic/Proposing.20Manuel.20Finelli.20as.20Project.20Lead.20for.20Narayana/with/591179257)
Current maintainers: https://github.com/jbosstm/narayana/wiki/List-of-Narayana-project-maintainers/bb53a29bc027200916a7325c9f587dfc19307dac
Mike and Marco: 
<img width="915" height="384" alt="image" src="https://github.com/user-attachments/assets/8db5b0b5-816b-4a22-9839-b198b274dc6a" />
Tom and Manuel:
<img width="806" height="164" alt="image" src="https://github.com/user-attachments/assets/f5468322-da90-4152-8540-290f8dd4a81d" />